### PR TITLE
【lsコマンドを作る2】 -aオプションを実装（隠しファイルを表示）

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -2,7 +2,6 @@
 
 require 'optparse'
 
-# PROGRAM_CONFIG = {}.freeze
 all = false
 opts = OptionParser.new
 opts.on('-a') { all = true }
@@ -15,12 +14,7 @@ def calc_max_width(file_names)
 end
 
 def fetch_visible_files(all:)
-  entries = if all
-              Dir.entries('.')
-            else
-              Dir.glob('*')
-            end
-  entries.sort
+  (all ? Dir.entries('.') : Dir.glob('*')).sort
 end
 
 def display_files(file_names, width)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
-require "optparse"
 
-ProgramConfig = {}
+require 'optparse'
+
+# PROGRAM_CONFIG = {}.freeze
+all = false
 opts = OptionParser.new
-opts.on('-a') { ProgramConfig[:a] = true }
+opts.on('-a') { all = true }
 opts.parse!(ARGV)
 
 COLUMN_COUNT = 3
@@ -13,12 +15,12 @@ def calc_max_width(file_names)
 end
 
 def fetch_visible_files(all:)
-  if all
-    entries = Dir.entries('.')
-  else
-    entries.glob('*')
-  end
-    entries.sort
+  entries = if all
+              Dir.entries('.')
+            else
+              Dir.glob('*')
+            end
+  entries.sort
 end
 
 def display_files(file_names, width)
@@ -37,6 +39,6 @@ def display_files(file_names, width)
   end
 end
 
-file_names = fetch_visible_files(all: ProgramConfig.key?(:a))
+file_names = fetch_visible_files(all: all)
 width = calc_max_width(file_names)
 display_files(file_names, width)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -14,7 +14,8 @@ def calc_max_width(file_names)
 end
 
 def fetch_visible_files(all:)
-  (all ? Dir.entries('.') : Dir.glob('*')).sort
+  flags = all ? File::FNM_DOTMATCH : 0
+  Dir.glob('*', flags).sort
 end
 
 def display_files(file_names, width)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -12,8 +12,13 @@ def calc_max_width(file_names)
   file_names.map(&:size).max
 end
 
-def fetch_visible_files
-  Dir.glob('*').sort
+def fetch_visible_files(all:)
+  if all
+    entries = Dir.entries('.')
+  else
+    entries.glob('*')
+  end
+    entries.sort
 end
 
 def display_files(file_names, width)
@@ -32,6 +37,6 @@ def display_files(file_names, width)
   end
 end
 
-file_names = fetch_visible_files
+file_names = fetch_visible_files(all: ProgramConfig.key?(:a))
 width = calc_max_width(file_names)
 display_files(file_names, width)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -33,6 +33,6 @@ def display_files(file_names, width)
   end
 end
 
-file_names = fetch_visible_files(all: all)
+file_names = fetch_visible_files(all:)
 width = calc_max_width(file_names)
 display_files(file_names, width)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
+require "optparse"
+
+ProgramConfig = {}
+opts = OptionParser.new
+opts.on('-a') { ProgramConfig[:a] = true }
+opts.parse!(ARGV)
 
 COLUMN_COUNT = 3
 


### PR DESCRIPTION
- `ls` コマンドに `-a` オプションを実装しました。
- `-a` 指定時は隠しファイルに加え `.` と `..` も表示します。