### PR TITLE
【lsコマンドを作る3】 -rオプションを実装

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -30,7 +30,8 @@ def display_files(file_names, width)
   row_count.times do |row_index|
     row = Array.new(COLUMN_COUNT) do |col_index|
       index = row_index + row_count * col_index
-      file_names[index].ljust(width)
+      name = file_names[index]
+      col_index == COLUMN_COUNT - 1 ? name : name.ljust(width)
     end
     puts row.join('  ')
   end

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -3,8 +3,11 @@
 require 'optparse'
 
 all = false
+reverse = false
+
 opts = OptionParser.new
 opts.on('-a') { all = true }
+opts.on('-r') { reverse = true }
 opts.parse!(ARGV)
 
 COLUMN_COUNT = 3

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -37,5 +37,6 @@ def display_files(file_names, width)
 end
 
 file_names = fetch_visible_files(all: all)
+file_names.reverse! if reverse
 width = calc_max_width(file_names)
 display_files(file_names, width)


### PR DESCRIPTION
`-r` オプションで逆順表示を実装しました。既存の3列レイアウトは維持し、表示前の配列にだけ逆順を適用しています。