### PR TITLE
【lsコマンドを作る4】 -lオプションを実装

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require 'optparse' # ← 追加：-l を受け取るため
-require 'etc' # ← 追加 : ユーザー/グループ名の取得に使用
+require 'optparse'
+require 'etc'
+require 'shellwords'
 
 COLUMN_COUNT = 3
 
@@ -67,8 +68,17 @@ if long
     ].join
     permstr = type_char + perms
 
+    # 拡張属性が付いている場合は @ を追加（macOS）
+    begin
+      xattr_output = `xattr -l -- #{Shellwords.escape(name)} 2>/dev/null`
+      has_xattr = !xattr_output.strip.empty?
+    rescue StandardError
+      has_xattr = false
+    end
+    permstr += '@' if has_xattr
+
     mtime = st.mtime.strftime('%Y-%m-%d %H:%M')
-    printf "%-10s %#{link_count_width}d %-#{user_name_width}s %-#{group_name_width}s %#{file_size_width}d %-#{mtime_width}s %s\n",
+    printf "%-11s %#{link_count_width}d %-#{user_name_width}s  %-#{group_name_width}s  %#{file_size_width}d  %-#{mtime_width}s %s\n",
            permstr, st.nlink, user, group, st.size, mtime, name
   end
 else

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -36,9 +36,10 @@ file_names = fetch_visible_files
 if long
   stats = file_names.map { |n| [n, File.lstat(n)] }
   link_count_width = [1, *stats.map { |_, st| st.nlink.to_s.size }].max
-  stats.each { |name, st| puts "#{st.nlink.to_s.rjust(link_count_width)} #{name}" }
-
-  # user_name_width = [1, *stats.map { |_, st| (Etc.getpwuid(st.uid)&.name || st.uid.to_s).size }].max
+  user_name_width = [1, *stats.map { |_, st| (Etc.getpwuid(st.uid)&.name || st.uid.to_s).size }].max
+  stats.each do |name, st|
+    printf "%#{link_count_width}d %-#{user_name_width}s %s\n", st.nlink, (Etc.getpwuid(st.uid)&.name || st.uid.to_s), name
+  end
   # group_name_width = [1, *stats.map { |_, st| (Etc.getgrgid(st.gid)&.name || st.gid.to_s).size }].max
   # file_size_width = [1, *stats.map { |_, st| st.size.to_s.size }].max
   # いったん動作確認として、-l は1行=1ファイルの暫定表示

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -39,12 +39,19 @@ if long
   user_name_width = [1, *stats.map { |_, st| (Etc.getpwuid(st.uid)&.name || st.uid.to_s).size }].max
   group_name_width = [1, *stats.map { |_, st| (Etc.getgrgid(st.gid)&.name || st.gid.to_s).size }].max
   file_size_width = [1, *stats.map { |_, st| st.size.to_s.size }].max
+  mtime_width = [1, *stats.map { |_, st| st.mtime.strftime('%Y-%m-%d %H:%M').size }].max
 
   stats.each do |name, st|
     user = Etc.getpwuid(st.uid)&.name || st.uid.to_s
     group = Etc.getgrgid(st.gid)&.name || st.gid.to_s
-    printf "%#{link_count_width}d %-#{user_name_width}s %-#{group_name_width}s %#{file_size_width}d %s\n",
-           st.nlink, user, group, st.size, name
+    mtime = st.mtime.strftime('%Y-%m-%d %H:%M')
+    printf "%#{link_count_width}d %-#{user_name_width}s %-#{group_name_width}s %#{file_size_width}d %-#{mtime_width}s %s\n",
+           st.nlink,
+           user,
+           group,
+           st.size,
+           mtime,
+           name
   end
 else
   width = calc_max_width(file_names)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -37,13 +37,15 @@ if long
   stats = file_names.map { |n| [n, File.lstat(n)] }
   link_count_width = [1, *stats.map { |_, st| st.nlink.to_s.size }].max
   user_name_width = [1, *stats.map { |_, st| (Etc.getpwuid(st.uid)&.name || st.uid.to_s).size }].max
+  group_name_width = [1, *stats.map { |_, st| (Etc.getgrgid(st.gid)&.name || st.gid.to_s).size }].max
+  file_size_width = [1, *stats.map { |_, st| st.size.to_s.size }].max
+
   stats.each do |name, st|
-    printf "%#{link_count_width}d %-#{user_name_width}s %s\n", st.nlink, (Etc.getpwuid(st.uid)&.name || st.uid.to_s), name
+    user = Etc.getpwuid(st.uid)&.name || st.uid.to_s
+    group = Etc.getgrgid(st.gid)&.name || st.gid.to_s
+    printf "%#{link_count_width}d %-#{user_name_width}s %-#{group_name_width}s %#{file_size_width}d %s\n",
+           st.nlink, user, group, st.size, name
   end
-  # group_name_width = [1, *stats.map { |_, st| (Etc.getgrgid(st.gid)&.name || st.gid.to_s).size }].max
-  # file_size_width = [1, *stats.map { |_, st| st.size.to_s.size }].max
-  # いったん動作確認として、-l は1行=1ファイルの暫定表示
-  file_names.each { |name| puts name }
 else
   width = calc_max_width(file_names)
   display_files(file_names, width)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -35,6 +35,9 @@ OptionParser.new { |opt| opt.on('-l') { long = true } }.parse!(ARGV)
 file_names = fetch_visible_files
 if long
   stats = file_names.map { |n| [n, File.lstat(n)] }
+  total_blocks = stats.sum { |_, st| st.blocks || ((st.size + 511) / 512) }
+  puts "total #{total_blocks}"
+
   link_count_width = [1, *stats.map { |_, st| st.nlink.to_s.size }].max
   user_name_width = [1, *stats.map { |_, st| (Etc.getpwuid(st.uid)&.name || st.uid.to_s).size }].max
   group_name_width = [1, *stats.map { |_, st| (Etc.getgrgid(st.gid)&.name || st.gid.to_s).size }].max


### PR DESCRIPTION
`-l` オプションの詳細表示を実装しました。種別(d/-/l 等)、rwx 権限、拡張属性 @、total（512B ブロック合計）、各列の桁揃え、mtime の6か月ルール（近い=時刻/古い=年）に対応しています。